### PR TITLE
Add optional close button

### DIFF
--- a/Titanium/ESTitaniumViewController.m
+++ b/Titanium/ESTitaniumViewController.m
@@ -85,6 +85,7 @@ static NSString * const kShowImageSegueIdentifier = @"ShowImage";
 
 - (void)showFrenchman {
     ESImageViewController *ivc = [[ESImageViewController alloc] init];
+    ivc.closeButton.hidden = NO;
     [ivc setTappedThumbnail:self.extraThumbnail];
     [ivc setImage:self.extraThumbnail.image];
     [self presentViewController:ivc animated:YES completion:nil];

--- a/Titanium/Titanium/ESImageViewController.h
+++ b/Titanium/Titanium/ESImageViewController.h
@@ -21,5 +21,9 @@
  */
 @property (strong, nonatomic) UIView *tappedThumbnail;
 
+/**
+ * Close button (hidden by default).
+ */
+@property (nonatomic, strong) UIButton *closeButton;
 
 @end

--- a/Titanium/Titanium/ESImageViewController.m
+++ b/Titanium/Titanium/ESImageViewController.m
@@ -33,6 +33,16 @@ CGFloat const kMaxImageScale = 3.0;
         // Custom initialization
         [self setModalPresentationStyle:UIModalPresentationCustom];
         [self setTransitioningDelegate:self];
+        
+        self.closeButton = [[UIButton alloc] init];
+        self.closeButton.layer.borderColor = [UIColor whiteColor].CGColor;
+        self.closeButton.layer.borderWidth = 1;
+        self.closeButton.layer.cornerRadius = 3;
+        self.closeButton.titleLabel.font = [UIFont systemFontOfSize:12];
+        [self.closeButton setTitle:@"Close" forState:UIControlStateNormal];
+        [self.closeButton addTarget:self action:@selector(dismissSelf) forControlEvents:UIControlEventTouchUpInside];
+        [self.view addSubview:self.closeButton];
+        self.closeButton.hidden = YES;
     }
     return self;
 }
@@ -65,6 +75,12 @@ CGFloat const kMaxImageScale = 3.0;
         [self deviceWillRotateTo:orientation];
     }];
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    
+
+    CGRect frame;
+    frame.size = CGSizeMake(70, 44);
+    frame.origin = CGPointMake(10, 10);
+    self.closeButton.frame = frame;
 }
 
 - (NSUInteger)supportedInterfaceOrientations {


### PR DESCRIPTION
Added a close button which is hidden by default. To show it, set the hidden property of `closeButton` to `NO` 

``` objc
- (void)showFrenchman {
     ESImageViewController *ivc = [[ESImageViewController alloc] init];
     ivc.closeButton.hidden = NO;
     [ivc setTappedThumbnail:self.extraThumbnail];
     [ivc setImage:self.extraThumbnail.image];
     [self presentViewController:ivc animated:YES completion:nil];
```
